### PR TITLE
ci: guard submodules, init only required; purge stale EdgeInfer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,81 @@
+name: CI
+on:
+  push: { branches: [ "**" ] }
+  pull_request: { branches: [ "**" ] }
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  ALLOWED_GITLINKS: |
+    DataDogsServer/h8-examples
+
+jobs:
+  build-and-test-linux:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout (no auto-submodules)
+        uses: actions/checkout@v4
+        with:
+          submodules: false
+          fetch-depth: 0
+
+      - name: Init required submodule only
+        run: |
+          set -euo pipefail
+          git submodule sync -- DataDogsServer/h8-examples
+          git submodule update --init -- DataDogsServer/h8-examples
+
+      - name: Show submodule status
+        run: |
+          git submodule status --recursive || true
+          echo "Gitlinks (mode 160000):"
+          git ls-files --stage | awk '$1=="160000"{print $4}'
+
+      - name: Assert allowed submodules (whitelist)
+        run: |
+          set -euo pipefail
+          gitlinks="$(git ls-files --stage | awk '$1=="160000"{print $4}')"
+          echo "Allowed:"
+          printf "%s\n" "$ALLOWED_GITLINKS"
+          echo "Found:"
+          printf "%s\n" "$gitlinks"
+          for g in $gitlinks; do
+            printf "%s\n" "$ALLOWED_GITLINKS" | grep -qx "$g" || { echo "Unexpected gitlink: $g"; exit 1; }
+          done
+
+      - name: Set up Swift
+        uses: swift-actions/setup-swift@v1
+        with:
+          swift-version: "6.0.2"
+
+      - name: Swift toolchain version
+        run: swift --version
+
+      - name: Install system deps (Vapor common)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libsqlite3-dev libssl-dev zlib1g-dev libcurl4-openssl-dev
+
+      - name: Cache SPM build artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            .build
+            ~/.swiftpm
+          key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
+          restore-keys: ${{ runner.os }}-spm-
+
+      - name: Resolve packages
+        run: swift package resolve
+
+      - name: Build (release)
+        run: swift build -c release --disable-sandbox
+
+      - name: Test
+        run: swift test --parallel --disable-sandbox

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ db.sqlite
 imu.json
 sample.mp4
 Tests/LinuxMain.swift
+
+model-runner/__pycache__/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
-[submodule "appdata/models/tcn_vae"]
-	path = appdata/models/tcn_vae
-	url = https://github.com/wllmflower2460/TCN-VAE_models.git
-	branch = main
+[submodule "DataDogsServer/h8-examples"]
+    path = DataDogsServer/h8-examples
+    url = https://github.com/hailo-ai/hailo-rpi5-examples.git
+    branch = main


### PR DESCRIPTION
Summary

Harden CI and fix submodule checkout failures by keeping only the required Hailo examples submodule and guarding against unexpected gitlinks.

What changed

Removed stale gitlink EdgeInfer/TCN-VAE_models (directory + metadata).

.gitmodules now contains only:

[submodule "DataDogsServer/h8-examples"]
    path = DataDogsServer/h8-examples
    url  = https://github.com/hailo-ai/hailo-rpi5-examples.git
    branch = main


Hardened CI (.github/workflows/ci.yml):

Checkout without auto-submodules.

Manually sync + update --init only DataDogsServer/h8-examples.

Whitelist guard: fails if any gitlink not in the allowed list appears.

Swift toolchain 6.0.2 via swift-actions/setup-swift.

SPM cache, resolve, release build, and parallel tests.

Tidiness: added model-runner/__pycache__/ to .gitignore.