### PR TITLE
docs: Consolidate submodule setup and PR template improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,25 @@
 
 Minimal Vapor-based inference edge service with feature‑flagged model sidecar, fast fallback, and multi‑Swift CI.
 
+## Development: Submodules
+
+This repo uses git submodules for model and example assets:
+
+- `appdata/models/tcn_vae` (TCN-VAE models)
+- `DataDogsServer/h8-examples` (Hailo Raspberry Pi 5 example pipelines)
+
+**First clone (with submodules):**
+```bash
+git clone --recurse-submodules git@github.com:wllmflower2460/pisrv_vapor_docker.git
+```
+
+**Existing clone (initialize submodules):**
+```bash
+git submodule update --init --recursive
+```
+
+CI note: GitHub Actions uses recursive checkout; see `.github/workflows/` for `submodules: recursive` plus gitlinks-only initialization.
+
 ## Features
 - HTTP API for submitting analysis windows (see routes under `/analysis`).
 - Feature flags:


### PR DESCRIPTION
## Summary
- Add comprehensive submodule setup instructions to README
- Include first-clone one-liner with `--recurse-submodules` 
- Document gitlinks-only initialization approach used in CI
- Consolidate documentation improvements from multiple doc branches

## Key Changes
**Submodule Documentation:**
- **First-clone snippet:** `git clone --recurse-submodules git@github.com:...`
- **Existing clone instructions:** `git submodule update --init --recursive` 
- **CI reference:** Notes about GitHub Actions gitlinks handling
- Lists both submodules: `appdata/models/tcn_vae` and `DataDogsServer/h8-examples`

**Developer Experience:**
- Clear distinction between first clone vs existing clone workflows
- References to CI submodule handling for context
- Maintains existing comprehensive README structure

## Test Plan
- [x] Documentation is clear and actionable for new contributors
- [x] Both submodule initialization methods documented
- [x] CI workflow references help understand automated approach
- [x] Existing README structure preserved

🤖 Generated with [Claude Code](https://claude.ai/code)